### PR TITLE
Replace `sendMiniMessage` with `sendRichMessage` in deprecation  annotations

### DIFF
--- a/src/main/kotlin/net/starlegacy/util/chat.kt
+++ b/src/main/kotlin/net/starlegacy/util/chat.kt
@@ -8,14 +8,14 @@ import org.bukkit.command.CommandSender
 import org.bukkit.entity.Player
 
 @Deprecated(
-	"Use Ion MiniMessage Extension Functions",
-	ReplaceWith("sendMiniMessage(text)", "net.horizonsend.ion.core.extensions.sendMiniMessage")
+	"Use Paper's MiniMessage Function",
+	ReplaceWith("sendRichMessage(text)")
 )
 infix fun CommandSender.msg(text: String) = this.sendMessage(text.colorize())
 
 @Deprecated(
-	"Use Ion MiniMessage Extension Functions",
-	ReplaceWith("sendMiniMessage(text)", "net.horizonsend.ion.core.extensions.sendMiniMessage")
+	"Use Paper's MiniMessage Function",
+	ReplaceWith("sendRichMessage(text)")
 )
 infix fun CommandSender.msg(text: TextComponent) = sendMessage(text)
 


### PR DESCRIPTION
`sendMiniMessageActionBar` is also mentioned in nearby deprecation annotations, but as far as I can tell it doesn't exist. 
As I don't know the replacement for it off the top of my head, I didn't touch it.