### PR TITLE
Fix buyxp command suggestion and use feedback

### DIFF
--- a/src/main/kotlin/net/starlegacy/command/progression/BuyXPCommand.kt
+++ b/src/main/kotlin/net/starlegacy/command/progression/BuyXPCommand.kt
@@ -2,6 +2,8 @@ package net.starlegacy.command.progression
 
 import co.aikar.commands.annotation.CommandAlias
 import co.aikar.commands.annotation.Optional
+import net.horizonsend.ion.core.feedback.FeedbackType.USER_ERROR
+import net.horizonsend.ion.core.feedback.sendFeedbackMessage
 import net.starlegacy.command.SLCommand
 import net.starlegacy.feature.progression.LEVEL_BALANCING
 import net.starlegacy.feature.progression.SLXP
@@ -9,6 +11,7 @@ import net.starlegacy.util.VAULT_ECO
 import net.starlegacy.util.toCreditsString
 import org.bukkit.entity.Player
 
+@Suppress("Unused")
 object BuyXPCommand : SLCommand() {
 	@CommandAlias("buyxp")
 	fun onExecute(sender: Player, amount: Int, @Optional cost: Double?) {
@@ -17,8 +20,12 @@ object BuyXPCommand : SLCommand() {
 		val realCost = LEVEL_BALANCING.creditsPerXP * amount
 		requireMoney(sender, realCost, "purchase $amount SLXP")
 
-		failIf(realCost != cost) {
-			"Purchase $amount SLXP for ${realCost.toCreditsString()}? To confirm, do /buyxp $amount $cost"
+		if (realCost != cost) {
+			sender.sendFeedbackMessage(USER_ERROR,
+				"Purchase {0} SLXP for {1}?\n" +
+						"To confirm, do <u><click:run_command:/buyxp $amount $realCost>/buyxp $amount $realCost</click>",
+				amount, realCost.toCreditsString())
+			return
 		}
 
 		VAULT_ECO.withdrawPlayer(sender, realCost)


### PR DESCRIPTION
Fixed the suggested `/buyxp` command showing "null" or the incorrect amount as the credit amount.
Also converted to use Feedback, as well as made the suggested command clickable.

![image](https://user-images.githubusercontent.com/66213737/190881275-bbc090dc-b703-4117-9b89-5c0cde87311f.png)
